### PR TITLE
Removed ref to defunct gopkgs.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@ Runtime dynamic library loader (dlopen / dlsym) for Go (golang)
 To install dl run the following command:
 
 ```
-    go get gopkgs.com/dl.v1
+    go get gopkg.in/rainycape/dl.v0
 ```
 
 
-Then use the following import path to ensure a stable API:
+Then use the following import path:
 
 ```go
-    import "gopkgs.com/dl.v1"
+    import "gopkg.in/rainycape/dl.v0"
 ```
 
 For documentation and available versions,
-see http://gopkgs.com/dl.
+see https://godoc.org/gopkg.in/rainycape/dl.v0 .


### PR DESCRIPTION
gopkgs.com is now defunct (see rainycape/dl#3)

However, we can almost achieve the same functionality with gokpg.in and godoc.org.

It would be necessary to create a release to provide a stable API, though.

Closes #3 